### PR TITLE
Force use of node20 when running the `generate-changelog` action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,5 @@ outputs:
      description: 'The generated changelog, as JSON'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
* https://github.com/warpdotdev/generate-changelog/pull/124  broke the most recently WarpDev release.
* This is because the version of octokit we depend on requires node 18 or higher: https://github.com/octokit/octokit.js/#fetch-missing
* This PR updates to node 20 directly, GH does not provide a `node18` option for runners, after a period of no node updates they decided to directly update to `node20`. See https://github.com/actions/runner/issues/2619#issuecomment-1643716450